### PR TITLE
Memorize current_#{group_name} to avoid error

### DIFF
--- a/lib/devise_token_auth/controllers/helpers.rb
+++ b/lib/devise_token_auth/controllers/helpers.rb
@@ -31,12 +31,6 @@ module DeviseTokenAuth
           class_eval <<-METHODS, __FILE__, __LINE__ + 1
             def authenticate_#{group_name}!(favourite=nil, opts={})
               unless #{group_name}_signed_in?
-                mappings = #{mappings}
-                mappings.unshift mappings.delete(favourite.to_sym) if favourite
-                mappings.each do |mapping|
-                  set_user_by_token(mapping)
-                end
-
                 unless current_#{group_name}
                   return render json: {
                     errors: ["Authorized users only."]
@@ -46,12 +40,14 @@ module DeviseTokenAuth
             end
 
             def #{group_name}_signed_in?
-              #{mappings}.any? do |mapping|
-                set_user_by_token(mapping)
-              end
+              !!current_#{group_name}
             end
 
             def current_#{group_name}(favourite=nil)
+              @current_#{group_name} ||= set_group_user_by_token(favourite)
+            end
+
+            def set_group_user_by_token(favourite)
               mappings = #{mappings}
               mappings.unshift mappings.delete(favourite.to_sym) if favourite
               mappings.each do |mapping|


### PR DESCRIPTION
Currently current_#{group_name} (e.g. current_member) is NOT memorized as current_#{mapping} (e.g.current_user) is.

Instead, it calls set_user_by_token every time, and this could cause error if current_member is called after token is changed (maybe by some other request) and return nil.

This PR also removes unnecessary set_user_by_token from authenticate_member!
